### PR TITLE
Fix renovate regex manager configuration for ruby gems

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,8 +7,9 @@
   "dependencyDashboard": true,
   "extends": ["config:base"],
   "rangeStrategy": "pin",
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^*.gemspec"],
       "matchStrings": [
         ".*\\.add_(:?(?<depType>.*?)_)?dependency\\s*(['\"])(?<depName>[^'\"]+)(['\"])(\\s*,\\s*(?<currentValue>(['\"])[^'\"]+['\"](\\s*,\\s*['\"][^'\"]+['\"])?))?"

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
-
 {
+  "includeForks": true,
   "automerge": false,
   "branchConcurrentLimit": 2,
   "branchPrefix": "renovate-",
@@ -11,9 +11,8 @@
     {
       "fileMatch": ["^*.gemspec"],
       "matchStrings": [
-        "^.*add.*dependency.*['\"](?<depName>.*?)['\"],.*['\"](?<currentValue>.*?)['\"].*"
+        ".*\\.add_(:?(?<depType>.*?)_)?dependency\\s*(['\"])(?<depName>[^'\"]+)(['\"])(\\s*,\\s*(?<currentValue>(['\"])[^'\"]+['\"](\\s*,\\s*['\"][^'\"]+['\"])?))?"
       ],
-      "depNameTemplate": "gemspec",
       "datasourceTemplate": "rubygems",
       "versioningTemplate": "ruby"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,7 @@
   "rangeStrategy": "pin",
   "customManagers": [
     {
+      "customType" : "regex",
       "fileMatch": [
         "^.*\\.gemspec"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": "Parse Ruby Gemspec files",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "customManagers": [
     {
@@ -27,7 +27,7 @@
         "^.*\\.gemspec"
       ],
       "matchManagers": [
-        "regex"
+        "custom.regex"
       ],
       "rangeStrategy": "replace"
     }

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
       "matchDatasources": [
         "rubygems"
       ],
-      "matchManagers ": [
+      "matchManagers": [
         "regex"
       ],
       "rangeStrategy": "auto"

--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,12 @@
   "branchPrefix": "renovate-",
   "bumpVersion": "patch",
   "dependencyDashboard": true,
-  "extends": ["config:base"],
-  "rangeStrategy": "auto",
+  "extends": [
+    "config:base"
+  ],
   "customManagers": [
     {
-      "customType" : "regex",
+      "customType": "regex",
       "fileMatch": [
         "^.*\\.gemspec"
       ],
@@ -18,6 +19,14 @@
       ],
       "datasourceTemplate": "rubygems",
       "versioningTemplate": "ruby"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchFileNames": [
+        "^.*\\.gemspec"
+      ],
+      "rangeStrategy": "auto"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,7 @@
   ],
   "packageRules": [
     {
+      "matchDatasources": ["rubygems "],
       "matchManagers ": [
         "regex"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": [
+      "matchManagers ": [
         "regex"
       ],
       "rangeStrategy": "auto"

--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,9 @@
   ],
   "packageRules": [
     {
-      "matchDatasources": ["rubygems "],
+      "matchDatasources": [
+        "rubygems"
+      ],
       "matchManagers ": [
         "regex"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,9 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "regex"
+      ],
       "matchFileNames": [
         "^.*\\.gemspec"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -9,8 +9,9 @@
   "rangeStrategy": "pin",
   "customManagers": [
     {
-      "customType": "regex",
-      "fileMatch": ["^*.gemspec"],
+      "fileMatch": [
+        "^.*\\.gemspec"
+      ],
       "matchStrings": [
         ".*\\.add_(:?(?<depType>.*?)_)?dependency\\s*(['\"])(?<depName>[^'\"]+)(['\"])(\\s*,\\s*(?<currentValue>(['\"])[^'\"]+['\"](\\s*,\\s*['\"][^'\"]+['\"])?))?"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "bumpVersion": "patch",
   "dependencyDashboard": true,
   "extends": ["config:base"],
-  "rangeStrategy": "pin",
+  "rangeStrategy": "auto",
   "customManagers": [
     {
       "customType" : "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -26,9 +26,6 @@
       "matchPackageNames": [
         "regex"
       ],
-      "matchFileNames": [
-        "^.*\\.gemspec"
-      ],
       "rangeStrategy": "auto"
     }
   ]

--- a/renovate.json
+++ b/renovate.json
@@ -23,9 +23,6 @@
       "matchDatasources": [
         "rubygems"
       ],
-      "matchFileNames": [
-        "^.*\\.gemspec"
-      ],
       "matchManagers": [
         "custom.regex"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,6 @@
 {
-  "includeForks": true,
-  "automerge": false,
-  "branchConcurrentLimit": 2,
-  "branchPrefix": "renovate-",
-  "bumpVersion": "patch",
-  "dependencyDashboard": true,
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Parse Ruby Gemspec files",
   "extends": [
     "config:base"
   ],
@@ -23,13 +19,17 @@
   ],
   "packageRules": [
     {
+      "description": "Applies \":preserveSemverRanges\" to the custom above manager. See: https://github.com/renovatebot/renovate/discussions/28090",
       "matchDatasources": [
         "rubygems"
+      ],
+      "matchFileNames": [
+        "^.*\\.gemspec"
       ],
       "matchManagers": [
         "regex"
       ],
-      "rangeStrategy": "auto"
+      "rangeStrategy": "replace"
     }
   ]
 }


### PR DESCRIPTION
- Removed redundant `depNameTemplate`
- Remove `^` from Match string
- Use version part of regex used in bundler https://github.com/renovatebot/renovate/blob/0151b6a4a90514acdcdbc46f22939cd71e28b874/lib/modules/manager/bundler/extract.ts#L47-L49